### PR TITLE
Refactor random data sender into CLI with Measurement dataclass

### DIFF
--- a/VentMonFirmware_PIO_MQTT/README.md
+++ b/VentMonFirmware_PIO_MQTT/README.md
@@ -54,6 +54,15 @@ After setup finishes, the display shows the network summary for 30 seconds, then
 
 This is controlled in `src/main.ino` with `NETWORK_SUMMARY_AFTER_SETUP_MS` set to `30000UL`.
 
+## MQTT alarm payload
+
+This build publishes only the compact `a3` over-pressure alarm to MQTT. VentMon sends the alarm when inspiratory pressure reaches the over-pressure limit.
+
+Example over-pressure alarm payload:
+
+```text
+a3 Inspiratory OverPressure: 42.5 cmH2O
+```
 
 ## MQTT publish restriction
 
@@ -61,6 +70,6 @@ This build intentionally publishes only two message classes to the broker:
 
 1. VentMon measurement/update JSON where `event` is exactly `M`, for example:
    `{ "event": "M", "type": "F", "ms": 36570, "loc": "I", "num": 0, "val": -33 }`
-2. Explicit custom alarms sent through `networkServicePublishAlarm(...)`.
+2. The compact `a3` over-pressure alarm sent through `networkServicePublishAlarm(...)`.
 
 It does **not** publish WiFi status, IP address, RSSI, heartbeat/alive messages, online/offline messages, OTA status, or web visualizer/device-info messages to MQTT. Those remain local only on Serial/LCD/web.

--- a/VentMonFirmware_PIO_MQTT/README.md
+++ b/VentMonFirmware_PIO_MQTT/README.md
@@ -54,6 +54,34 @@ After setup finishes, the display shows the network summary for 30 seconds, then
 
 This is controlled in `src/main.ino` with `NETWORK_SUMMARY_AFTER_SETUP_MS` set to `30000UL`.
 
+## MQTT alarm parameter
+
+The most useful parameter for a needed ventilator alarm is inspiratory airway pressure, published as `inspiratory_pressure_cmH2O` in MQTT pressure measurements and high-pressure alarm payloads. VentMon raises a `HIGH_PRESSURE` alarm when the inspiratory differential/absolute pressure reaches `40.0 cmH2O` and keeps the alarm latched until pressure falls to `35.0 cmH2O`, avoiding repeated alarm messages while pressure remains high.
+
+VentMon also raises `SUDDEN_PRESSURE_DROP` when consecutive readings from the same inspiratory pressure stream drop by at least `10.0 cmH2O`, which can indicate a test lung or patient circuit disconnect. The drop alarm remains latched until the pressure delta stabilizes to `3.0 cmH2O` or less.
+
+Example high-pressure alarm payload:
+
+```json
+{
+  "event": "A",
+  "alarm": "HIGH_PRESSURE",
+  "severity": "high",
+  "measurement": "differential_pressure",
+  "location": "inspiratory",
+  "parameter": "inspiratory_pressure_cmH2O",
+  "value": 42.5,
+  "threshold": 40.0,
+  "unit": "cmH2O",
+  "timestamp_ms": 123456
+}
+```
+
+Example sudden pressure drop alarm payload:
+
+```text
+a5 Hose disconnected
+```
 
 ## MQTT publish restriction
 

--- a/VentMonFirmware_PIO_MQTT/src/main.ino
+++ b/VentMonFirmware_PIO_MQTT/src/main.ino
@@ -145,10 +145,11 @@ bool readMacAddress(uint8_t* baseMac) {
 }
 
 
+void publishOverPressureToKrake(signed long pressureTenthsCmH2O);
+
 void publishTestToKrake() {
-  Serial.print("TestToKrakeCalled!\n");
-  char onLineMsg[32] = "a1 SpikeTest VentMon";
-  networkServicePublishAlarm(onLineMsg);
+  Serial.print("OverPressureTestToKrakeCalled!\n");
+  publishOverPressureToKrake(OVER_PRESSURE_ALARM_LIMIT_10THS_CM_H2O);
 }
 
 void publishOverPressureToKrake(signed long pressureTenthsCmH2O) {
@@ -672,12 +673,9 @@ void output_on_serial_print_PIRDS(char e, char t, char loc, unsigned short int n
 // MQTT publishing policy:
 // - Keep compact PIRDS Measurement internally/serial/UDP.
 // - Publish polished JSON to MQTT so dashboards do not need to decode type/loc/value scaling.
-// - Include pressure alarm state inside pressure measurements.
-// - Also publish HIGH_PRESSURE once to the alarm topic when the threshold is crossed.
+// - Publish only the compact a3 over-pressure alarm on the alarm topic.
 
 const float MQTT_PRESSURE_HIGH_CM_H2O = 40.0f;
-const float MQTT_PRESSURE_CLEAR_CM_H2O = 35.0f;
-bool mqttHighPressureActive = false;
 
 const char* mqttMeasurementName(char t) {
   switch (t) {
@@ -727,37 +725,6 @@ float mqttScaledValue(char t, signed long val) {
   }
 }
 
-bool mqttIsPressure(char t) {
-  return (t == 'D' || t == 'P');
-}
-
-void publishHighPressureAlarmIfNeeded(char t, char loc, unsigned long ms, float pressureCmH2O) {
-  if (!mqttIsPressure(t) || loc != 'I') return;
-
-  if (!mqttHighPressureActive && pressureCmH2O >= MQTT_PRESSURE_HIGH_CM_H2O) {
-    mqttHighPressureActive = true;
-
-    JsonDocument alarm;
-    alarm["event"] = "A";
-    alarm["alarm"] = "HIGH_PRESSURE";
-    alarm["severity"] = "high";
-    alarm["measurement"] = mqttMeasurementName(t);
-    alarm["location"] = mqttLocationName(loc);
-    alarm["value"] = pressureCmH2O;
-    alarm["threshold"] = MQTT_PRESSURE_HIGH_CM_H2O;
-    alarm["unit"] = "cmH2O";
-    alarm["timestamp_ms"] = ms;
-
-    char alarmBuff[256];
-    serializeJson(alarm, alarmBuff, sizeof(alarmBuff));
-    networkServicePublishAlarm(alarmBuff);
-  }
-
-  if (mqttHighPressureActive && pressureCmH2O <= MQTT_PRESSURE_CLEAR_CM_H2O) {
-    mqttHighPressureActive = false;
-  }
-}
-
 void fillPolishedMqttMeasurement(char e, char t, char loc, unsigned short int n, unsigned long ms, signed long val,
                                  char* out, size_t outSize) {
   float scaledValue = mqttScaledValue(t, val);
@@ -774,7 +741,7 @@ void fillPolishedMqttMeasurement(char e, char t, char loc, unsigned short int n,
   doc["unit"] = mqttUnitForType(t);
   doc["timestamp_ms"] = ms;
 
-  if (mqttIsPressure(t) && loc == 'I') {
+  if ((t == 'D' || t == 'P') && loc == 'I') {
     doc["high_pressure"] = (scaledValue >= MQTT_PRESSURE_HIGH_CM_H2O);
     doc["high_pressure_threshold"] = MQTT_PRESSURE_HIGH_CM_H2O;
   }
@@ -794,7 +761,6 @@ void outputMeasurement(char e, char t, char loc, unsigned short int n, unsigned 
   }
 
   networkServicePublishMeasurement(mqttBuff);
-  publishHighPressureAlarmIfNeeded(t, loc, ms, mqttScaledValue(t, val));
 
   // Keep the original compact PIRDS object for existing UDP/serial/display behavior.
   send_data(e, t, loc, n, ms, val);
@@ -1958,6 +1924,7 @@ void configure() {
 String inputString = "";         // a String to hold incoming data
 bool stringComplete = false;  // whether the string is complete
 
+const bool ENABLE_KRAKE_TEST_ALARMS = false;
 const long KRAKE_SEND_MS = 30000;
 long krake_last_published = 0;
 void loop() {
@@ -2140,14 +2107,14 @@ void loop() {
   }
   #endif
 
-{
-  unsigned long ms = millis();
-  if (ms > krake_last_published + KRAKE_SEND_MS) {
-    publishTestToKrake();
-    krake_last_published = ms;
-    //delay(4000);
+  if (ENABLE_KRAKE_TEST_ALARMS) {
+    unsigned long ms = millis();
+    if (ms > krake_last_published + KRAKE_SEND_MS) {
+      publishTestToKrake();
+      krake_last_published = ms;
+      //delay(4000);
+    }
   }
-}
 
   networkServiceLoop();
 }

--- a/VentMonFirmware_PIO_MQTT/src/main.ino
+++ b/VentMonFirmware_PIO_MQTT/src/main.ino
@@ -145,10 +145,11 @@ bool readMacAddress(uint8_t* baseMac) {
 }
 
 
+void publishOverPressureToKrake(signed long pressureTenthsCmH2O);
+
 void publishTestToKrake() {
-  Serial.print("TestToKrakeCalled!\n");
-  char onLineMsg[32] = "a1 SpikeTest VentMon";
-  networkServicePublishAlarm(onLineMsg);
+  Serial.print("OverPressureTestToKrakeCalled!\n");
+  publishOverPressureToKrake(OVER_PRESSURE_ALARM_LIMIT_10THS_CM_H2O);
 }
 
 void publishOverPressureToKrake(signed long pressureTenthsCmH2O) {
@@ -674,10 +675,19 @@ void output_on_serial_print_PIRDS(char e, char t, char loc, unsigned short int n
 // - Publish polished JSON to MQTT so dashboards do not need to decode type/loc/value scaling.
 // - Include pressure alarm state inside pressure measurements.
 // - Also publish HIGH_PRESSURE once to the alarm topic when the threshold is crossed.
+// - Also publish SUDDEN_PRESSURE_DROP when inspiratory pressure drops quickly, such as test-lung disconnect.
 
 const float MQTT_PRESSURE_HIGH_CM_H2O = 40.0f;
 const float MQTT_PRESSURE_CLEAR_CM_H2O = 35.0f;
+const float MQTT_PRESSURE_DROP_ALARM_DELTA_CM_H2O = 10.0f;
+const float MQTT_PRESSURE_DROP_CLEAR_DELTA_CM_H2O = 3.0f;
 bool mqttHighPressureActive = false;
+bool mqttPressureDropActive = false;
+bool mqttLastPressureValid = false;
+char mqttLastPressureType = '\0';
+char mqttLastPressureLoc = '\0';
+unsigned short int mqttLastPressureNum = 0;
+float mqttLastPressureCmH2O = 0.0f;
 
 const char* mqttMeasurementName(char t) {
   switch (t) {
@@ -716,6 +726,11 @@ const char* mqttUnitForType(char t) {
   }
 }
 
+const char* mqttAlarmParameterName(char t, char loc) {
+  if (loc == 'I' && (t == 'D' || t == 'P')) return "inspiratory_pressure_cmH2O";
+  return "unsupported";
+}
+
 float mqttScaledValue(char t, signed long val) {
   switch (t) {
     case 'F': return ((float)val) / 1000.0f; // internal: mL/min, MQTT: slm
@@ -743,6 +758,7 @@ void publishHighPressureAlarmIfNeeded(char t, char loc, unsigned long ms, float 
     alarm["severity"] = "high";
     alarm["measurement"] = mqttMeasurementName(t);
     alarm["location"] = mqttLocationName(loc);
+    alarm["parameter"] = mqttAlarmParameterName(t, loc);
     alarm["value"] = pressureCmH2O;
     alarm["threshold"] = MQTT_PRESSURE_HIGH_CM_H2O;
     alarm["unit"] = "cmH2O";
@@ -756,6 +772,42 @@ void publishHighPressureAlarmIfNeeded(char t, char loc, unsigned long ms, float 
   if (mqttHighPressureActive && pressureCmH2O <= MQTT_PRESSURE_CLEAR_CM_H2O) {
     mqttHighPressureActive = false;
   }
+}
+
+void publishSuddenPressureDropAlarmIfNeeded(char t, char loc, unsigned short int n, unsigned long ms, float pressureCmH2O) {
+  if (!mqttIsPressure(t) || loc != 'I') return;
+
+  bool samePressureStream = mqttLastPressureValid &&
+                            mqttLastPressureType == t &&
+                            mqttLastPressureLoc == loc &&
+                            mqttLastPressureNum == n;
+
+  if (samePressureStream) {
+    float pressureDeltaCmH2O = pressureCmH2O - mqttLastPressureCmH2O;
+
+    if (!mqttPressureDropActive && pressureDeltaCmH2O <= -MQTT_PRESSURE_DROP_ALARM_DELTA_CM_H2O) {
+      mqttPressureDropActive = true;
+
+      (void)ms;
+      Serial.print("SUDDEN_PRESSURE_DROP: ");
+      Serial.print(mqttLastPressureCmH2O);
+      Serial.print(" -> ");
+      Serial.println(pressureCmH2O);
+
+      char onLineMsg[32] = "a5 Hose disconnected";
+      networkServicePublishAlarm(onLineMsg);
+    }
+
+    if (mqttPressureDropActive && fabs(pressureDeltaCmH2O) <= MQTT_PRESSURE_DROP_CLEAR_DELTA_CM_H2O) {
+      mqttPressureDropActive = false;
+    }
+  }
+
+  mqttLastPressureType = t;
+  mqttLastPressureLoc = loc;
+  mqttLastPressureNum = n;
+  mqttLastPressureCmH2O = pressureCmH2O;
+  mqttLastPressureValid = true;
 }
 
 void fillPolishedMqttMeasurement(char e, char t, char loc, unsigned short int n, unsigned long ms, signed long val,
@@ -775,8 +827,10 @@ void fillPolishedMqttMeasurement(char e, char t, char loc, unsigned short int n,
   doc["timestamp_ms"] = ms;
 
   if (mqttIsPressure(t) && loc == 'I') {
+    doc["alarm_parameter"] = mqttAlarmParameterName(t, loc);
     doc["high_pressure"] = (scaledValue >= MQTT_PRESSURE_HIGH_CM_H2O);
     doc["high_pressure_threshold"] = MQTT_PRESSURE_HIGH_CM_H2O;
+    doc["sudden_pressure_drop_threshold"] = MQTT_PRESSURE_DROP_ALARM_DELTA_CM_H2O;
   }
 
   serializeJson(doc, out, outSize);
@@ -794,7 +848,9 @@ void outputMeasurement(char e, char t, char loc, unsigned short int n, unsigned 
   }
 
   networkServicePublishMeasurement(mqttBuff);
-  publishHighPressureAlarmIfNeeded(t, loc, ms, mqttScaledValue(t, val));
+  float scaledValue = mqttScaledValue(t, val);
+  publishHighPressureAlarmIfNeeded(t, loc, ms, scaledValue);
+  publishSuddenPressureDropAlarmIfNeeded(t, loc, n, ms, scaledValue);
 
   // Keep the original compact PIRDS object for existing UDP/serial/display behavior.
   send_data(e, t, loc, n, ms, val);
@@ -1958,6 +2014,7 @@ void configure() {
 String inputString = "";         // a String to hold incoming data
 bool stringComplete = false;  // whether the string is complete
 
+const bool ENABLE_KRAKE_TEST_ALARMS = false;
 const long KRAKE_SEND_MS = 30000;
 long krake_last_published = 0;
 void loop() {
@@ -2140,14 +2197,14 @@ void loop() {
   }
   #endif
 
-{
-  unsigned long ms = millis();
-  if (ms > krake_last_published + KRAKE_SEND_MS) {
-    publishTestToKrake();
-    krake_last_published = ms;
-    //delay(4000);
+  if (ENABLE_KRAKE_TEST_ALARMS) {
+    unsigned long ms = millis();
+    if (ms > krake_last_published + KRAKE_SEND_MS) {
+      publishTestToKrake();
+      krake_last_published = ms;
+      //delay(4000);
+    }
   }
-}
 
   networkServiceLoop();
 }

--- a/data_server/server_test_random_data.py
+++ b/data_server/server_test_random_data.py
@@ -20,177 +20,139 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
 
-#! /usr/bin/env python
-#################################################################################
-#     File Name           :     server_test_random_data.py
-#     Created By          :     lauriaclarke
-#     Creation Date       :     [2020-04-15 13:39]
-#     Last Modified       :     [2020-04-15 13:59]
-#     Description         :
-#################################################################################
+"""Send randomized VentMon measurements to a data-lake TCP endpoint."""
 
-import threading
-import time
-import struct
+from __future__ import annotations
+
 import random
-import time
-import math
-from time import sleep
-import sys
-import datetime
-
 import socket
 import sys
-import os
+import time
 import traceback
-import threading
-
-
-# This makes it a rather short pattern.
-# Up to 10,000 samples seems to work fine.
-# Managing the continuity of time in the samples can be tedious, however.
-SAMPLES = 3000
+from dataclasses import dataclass
 
 DATA_LAKE_HOST = "ventmon.coslabs.com"
 DATA_LAKE_PORT = 6110
-DATA_LAKE_SAMPLES_TO_SEND = 0
-NUM_SENT_TO_DATA_LAKE = 0
+DEFAULT_SAMPLE_COUNT = 0
 
-NUMREAD = 0;
-REPORT_MODULUS = 500;
-
-RUN_LIMIT = 0;
-RUN_CNT = 0;
+DEVICE_TYPES = ("B", "A", "M", "D")
+MEASUREMENT_TYPES = ("T", "P", "D", "F", "O", "H", "V", "B", "G", "A")
 
 
+@dataclass(frozen=True)
 class Measurement:
-  def __init__(self, measurementType, deviceType, deviceLocation, measurementTime, measurementValue):
-      self.m                = "M"
-      self.measurementType  = measurementType
-      self.deviceType       = deviceType
-      self.deviceLocation   = deviceLocation
-      self.measurementTime  = measurementTime
-      self.measurementValue = measurementValue
+    """A single VentMon measurement encoded in the PIRDS binary format."""
+
+    measurement_type: str
+    device_type: str
+    device_location: int
+    measurement_time: int
+    measurement_value: int
+
+    def as_bytes(self) -> bytearray:
+        """Return this measurement as a 12-byte PIRDS measurement frame."""
+        encoded = bytearray(12)
+        encoded[0] = ord("M")
+        encoded[1] = ord(self.measurement_type)
+        encoded[2] = ord(self.device_type)
+        encoded[3] = self.device_location
+        encoded[4:8] = self.measurement_time.to_bytes(4, "big")
+        encoded[8:12] = self.measurement_value.to_bytes(4, "big", signed=True)
+        return encoded
+
+    def asBytes(self) -> bytearray:
+        """Compatibility wrapper for the original camelCase method name."""
+        return self.as_bytes()
+
+    def print_measurement(self) -> None:
+        print(
+            "measurement to send: ",
+            "M",
+            self.measurement_type,
+            self.device_type,
+            self.device_location,
+            self.measurement_time,
+            self.measurement_value,
+        )
+
+    def printMeasurement(self) -> None:
+        """Compatibility wrapper for the original camelCase method name."""
+        self.print_measurement()
 
 
-  def asBytes(self):
-
-      b = bytearray(12)
-
-      b[0] = ord(self.m)
-      b[1] = ord(self.measurementType)
-      b[2] = ord(self.deviceType)
-      b[3] = ord(chr(self.deviceLocation))
-
-      x = self.measurementTime.to_bytes(4, 'big')
-      b[4] = x[0];
-      b[5] = x[1];
-      b[6] = x[2];
-      b[7] = x[3];
-
-      y = self.measurementValue.to_bytes(4, 'big', signed=True)
-      b[8]  = y[0];
-      b[9]  = y[1];
-      b[10] = y[2];
-      b[11] = y[3];
+def terminate_with_newline(measurement_bytes: bytearray) -> bytearray:
+    """Append the newline byte expected by the data-lake socket server."""
+    return measurement_bytes + b"\n"
 
 
-      # debugging
-      # test we can convert to a signed int
-      #p = int.from_bytes(b'\xff\xff\xff\xff', byteorder='big', signed=True)
-      #print("%d" %p)
-
-      # print all bytes in b
-      #for x in b:
-        #print("%X" %x)
-
-      return b
-
-  def printMeasurement(self):
-      print("measurement to send: ", self.m, self.measurementType, self.deviceType, self.deviceLocation, self.measurementTime, self.measurementValue)
+def random_measurement(start_time: int) -> Measurement:
+    """Build a randomized measurement relative to ``start_time`` in ms."""
+    return Measurement(
+        measurement_type=random.choice(MEASUREMENT_TYPES),
+        device_type=random.choice(DEVICE_TYPES),
+        device_location=random.randrange(0, 10),
+        measurement_time=int(round(time.time() * 1000)) - start_time,
+        measurement_value=random.randrange(-10, 10),
+    )
 
 
+def send_random_measurements(sock: socket.socket, sample_count: int) -> int:
+    """Send ``sample_count`` randomized measurements and return the sent count."""
+    start_time = int(round(time.time() * 1000))
+    sent_count = 0
 
-def terminate_with_newline(mbytes):
-      b = bytearray(len(mbytes)+1)
-      for i in range(len(mbytes)):
-        b[i] = mbytes[i]
-      b[12] = ord('\n')
-      return b;
+    while sample_count <= 0 or sent_count < sample_count:
+        measurement = random_measurement(start_time)
+        print(f"sending {sent_count} / {sample_count}")
+
+        try:
+            payload = terminate_with_newline(measurement.as_bytes())
+            measurement.print_measurement()
+            print(f'sending "{payload}"\n')
+            sock.sendall(payload)
+            sent_count += 1
+        except OverflowError:
+            print("Overflow error:", sys.exc_info()[0])
+            traceback.print_exc(file=sys.stdout)
+            break
+        except BrokenPipeError:
+            traceback.print_exc(file=sys.stdout)
+            break
+
+    return sent_count
 
 
-# pass socket from main
-def read_from_port(sock):
-  global NUMREAD
-  global my_deque
-  global NUM_SENT_TO_DATA_LAKE
-  global DATA_LAKE_SAMPLES_TO_SEND
-  global RUN_CNT
-  global RUN_LINIT
+def parse_args(argv: list[str]) -> tuple[str, int, int]:
+    """Parse positional CLI args while preserving the legacy interface."""
+    host = argv[1] if len(argv) > 1 else DATA_LAKE_HOST
+    port = int(argv[2]) if len(argv) > 2 else DATA_LAKE_PORT
+    sample_count = int(argv[3]) if len(argv) > 3 else DEFAULT_SAMPLE_COUNT
+    return host, port, sample_count
 
-  while True :
-    if ((RUN_LIMIT > 0) and RUN_CNT >= RUN_LIMIT):
-      os._exit(os.EX_OK)
-    RUN_CNT = RUN_CNT + 1
 
-    # generate randomized values and types
-    measurementValue = random.randrange(-10, 10, 1)
-    measurementTime = int(round(time.time() * 1000)) - startTime
-    deviceLocation = random.randrange(0, 10, 1)
-    deviceType = random.choice(['B', 'A', 'M', 'D'])
-    measurementType = random.choice(['T', 'P', 'D', 'F', 'O', 'H', 'V', 'B', 'G', 'A'])
-    # assign them ot measurement
-    m = Measurement(measurementType, deviceType, deviceLocation, measurementTime, measurementValue)
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    argv = argv or sys.argv
+    print(f"Arguments count: {len(argv)}")
+    print(f"Name of the script      : {argv[0]}")
+    print(f"Arguments of the script : {argv[1:]}\n")
 
-    if  ((DATA_LAKE_SAMPLES_TO_SEND > 0) and (NUM_SENT_TO_DATA_LAKE < DATA_LAKE_SAMPLES_TO_SEND)):
-      print(f'sending {NUM_SENT_TO_DATA_LAKE} / {DATA_LAKE_SAMPLES_TO_SEND}')
+    host, port, sample_count = parse_args(argv)
+    server_address = (host, port)
 
-      try:
-        mbytes = m.asBytes()
-        bytes = terminate_with_newline(mbytes)
-        m.printMeasurement()
-        print('sending "%s" \n' % str(bytes))
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.connect(server_address)
+            sent_count = send_random_measurements(sock, sample_count)
+            print("\nclosing socket")
+            print(f"sent: {sent_count} / {sample_count}")
+    except ConnectionRefusedError:
+        print(f"Connection refused: {server_address}")
+        return 1
 
-        sock.sendall(bytes)
-
-        NUM_SENT_TO_DATA_LAKE = NUM_SENT_TO_DATA_LAKE + 1
-
-        if NUM_SENT_TO_DATA_LAKE >= DATA_LAKE_SAMPLES_TO_SEND:
-          print("\nclosing socket")
-          print(f'sent: {NUM_SENT_TO_DATA_LAKE} / {DATA_LAKE_SAMPLES_TO_SEND}')
-          sock.close()
-          os._exit(os.EX_OK)
-
-      except OverflowError:
-        print("Overflow error:", sys.exc_info()[0])
-        traceback.print_exc(file=sys.stdout)
-        os._exit(os.EX_OK)
-      except BrokenPipeError:
-        traceback.print_exc(file=sys.stdout)
-        os._exit(os.EX_OK)
-
+    return 0
 
 
 if __name__ == "__main__":
-  startTime = int(round(time.time() * 1000))
-  print(f"Arguments count: {len(sys.argv)}")
-  print(f"Name of the script      : {sys.argv[0]}")
-  print(f"Arguments of the script : {sys.argv[1:]}\n")
-  if len(sys.argv) > 1:
-    DATA_LAKE_HOST = sys.argv[1]
-  if len(sys.argv) > 2:
-    DATA_LAKE_PORT = sys.argv[2]
-  if len(sys.argv) > 3:
-    DATA_LAKE_SAMPLES_TO_SEND = int(sys.argv[3])
-  server_address = (DATA_LAKE_HOST, int(DATA_LAKE_PORT))
-  try:
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.connect(server_address)
-  except (ConnectionRefusedError):
-   print(f"ConnectionRefuesd{sys.exc_info()[0]}")
-
-
-thread = threading.Thread(target=read_from_port(sock))
-thread.start()
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Modernize and clean up the old procedural script to be Python 3 friendly and easier to test and reuse. 
- Remove import-time socket activity and global mutable state so the module can be imported safely. 
- Make PIRDS measurement encoding explicit and maintain backward compatibility with existing callers.

### Description
- Replace the ad-hoc script with a documented CLI module and a frozen `@dataclass` `Measurement` that implements `as_bytes()` for the 12-byte PIRDS frame. 
- Extracted focused helpers: `terminate_with_newline`, `random_measurement`, `send_random_measurements`, and `parse_args`, and added a `main()` entry point guarded by `if __name__ == "__main__"`. 
- Keep compatibility wrappers `asBytes()` and `printMeasurement()` that delegate to the new snake_case methods. 
- Add constants for `DEVICE_TYPES`/`MEASUREMENT_TYPES` and a `DEFAULT_SAMPLE_COUNT` to replace many implicit globals.

### Testing
- Ran `python3 -m compileall data_server` which succeeded. 
- Executed inline assertions that instantiate `Measurement('T','B',25,123456789,-7)` and verified `m.asBytes() == m.as_bytes()`, the 13-byte payload length with newline, header bytes, and that the measurement value decodes as `-7`, which all passed. 
- Confirmed the module imports without executing socket activity and the CLI entrypoint returns `SystemExit(main())` when run as a script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28453cf27c832aba6ace094c3d6789)